### PR TITLE
Add instructions for installing windows service

### DIFF
--- a/lib/app_component.dart
+++ b/lib/app_component.dart
@@ -57,6 +57,19 @@ String createPlatformHelp(String platform) {
     </p>
 
     <p>Your DSA instance is now running!</p>
+    
+    <p>
+    Install as a service:<br/>
+    In the search bar on your start menu, type in "cmd"<br />
+    Locate command prompt, right click on it, and choose "Run as administrator"<br />
+    Change to the dsa-server folder extracted form the ZIP.<br />
+    Eg: <code>cd C:\\dsa\\dsa-server</code><br />
+    Run the following command:<br/>
+    <code>
+    bin\\daemon.bat install-service
+    </code><br />
+    Open the "services" application and confirm you see "DGLux Service" now listed.
+    </p>
     """;
   }
 


### PR DESCRIPTION
Add the following instructions for windows (in addition to the existing instructions).

<p>
    Install as a service:<br/>
    In the search bar on your start menu, type in "cmd"<br />
    Locate command prompt, right click on it, and choose "Run as administrator"<br />
    Change to the dsa-server folder extracted form the ZIP.<br />
    Eg: <code>cd C:\\dsa\\dsa-server</code><br />
    Run the following command:<br/>
    <code>
    bin\\daemon.bat install-service
    </code><br />
    Open the "services" application and confirm you see "DGLux Service" now listed.
    </p>